### PR TITLE
Set the correct initial values for token and secret

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -17,12 +17,15 @@ class Config
     const SDK_HOST = 'sdk.loyaltylion.net';
 
     private $_scopeConfig;
+    private $token;
+    private $secret;
 
     public function __construct(
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
     )
     {
         $this->_scopeConfig = $scopeConfig;
+        $this->isEnabledInContext();
     }
 
     public function isEnabledInContext()


### PR DESCRIPTION
Fixes an issue where logging in may not have been possible in magento2. This happens because of an incorrect setting in out config helper, that caused some of the magento block caching requests to fail.

Failing Example: http://recordit.co/3RZgU0PfEY
Successful Example: http://recordit.co/KMiErToZDW