### PR TITLE
phpcs: ignore InstallData.php

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -16,4 +16,6 @@
    <exclude name="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket"/>
  </rule>
  <exclude-pattern>vendor/*</exclude-pattern>
+ <exclude-pattern>node_modules/*</exclude-pattern>
+ <exclude-pattern>Setup/*</exclude-pattern>
 </ruleset>


### PR DESCRIPTION
this still appears to be the documented way of doing what we need to do: https://developer.adobe.com/commerce/webapi/get-started/create-integration/